### PR TITLE
improvements(lua): lock lua release into a specific version (5.3)

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -98,7 +98,7 @@ endif ()
 if (USE_LUA_ANTARA_WRAPPER)
     FetchContent_Declare(
             lua
-            URL https://github.com/lua/lua/archive/master.zip
+            URL https://github.com/lua/lua/archive/v5.3.5.zip
     )
 
     FetchContent_Declare(


### PR DESCRIPTION
I was having some weird linking issues with Lua and sol2, and I decided to take a peek at how it was being downloaded, and I figure that building against a constantly changing master is probably not a good idea.

If you want to use a newer version of Lua (5.4 beta is the latest tag) I can update the PR.